### PR TITLE
Windows用のサポートを追加

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,14 @@ var sources = [
 var resources: [Resource] = []
 var linkerSettings: [LinkerSetting] = []
 var cSettings: [CSetting] =  [
-    // .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
-    // .unsafeFlags(["-fno-objc-arc"]),
+    .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
+    .unsafeFlags(["-fno-objc-arc"]),
     // NOTE: NEW_LAPACK will required iOS version 16.4+
     // We should consider add this in the future when we drop support for iOS 14
     // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
     // .define("ACCELERATE_NEW_LAPACK"),
     // .define("ACCELERATE_LAPACK_ILP64")
 ]
-var cxxVersion: CXXLanguageStandard = .cxx11
 
 #if canImport(Darwin)
 sources.append("ggml-metal.m")
@@ -46,7 +45,6 @@ cSettings.append(
     // Workaround of https://github.com/llvm/llvm-project/issues/40056
     cSettings.append(.unsafeFlags(["-Xclang", "-fno-split-cold-code"]))
     cSettings.append(.unsafeFlags(["-Wdeprecated-declarations"]))
-    cxxVersion = .cxx14
 #endif
 
 let package = Package(
@@ -82,5 +80,5 @@ let package = Package(
             linkerSettings: linkerSettings
         )
     ],
-    cxxLanguageStandard: cxxVersion
+    cxxLanguageStandard: .cxx14
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ var cSettings: [CSetting] =  [
     // .define("ACCELERATE_NEW_LAPACK"),
     // .define("ACCELERATE_LAPACK_ILP64")
 ]
+var cxxVersion: CXXLanguageStandard = .cxx11
 
 #if canImport(Darwin)
 sources.append("ggml-metal.m")
@@ -44,6 +45,7 @@ cSettings.append(
 #if os(Windows)
     cSettings.append(.unsafeFlags(["-Xclang", "-fno-split-cold-code"]))
     cSettings.append(.unsafeFlags(["-Wdeprecated-declarations"]))
+    cxxVersion = .cxx14
 #endif
 
 let package = Package(
@@ -79,5 +81,5 @@ let package = Package(
             linkerSettings: linkerSettings
         )
     ],
-    cxxLanguageStandard: .cxx14
+    cxxLanguageStandard: cxxVersion
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ var resources: [Resource] = []
 var linkerSettings: [LinkerSetting] = []
 var cSettings: [CSetting] =  [
     // .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
-    // Workaround of https://github.com/llvm/llvm-project/issues/40056
+    // .unsafeFlags(["-fno-objc-arc"]),
     // NOTE: NEW_LAPACK will required iOS version 16.4+
     // We should consider add this in the future when we drop support for iOS 14
     // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
@@ -42,6 +42,7 @@ cSettings.append(
 #endif
 
 #if os(Windows)
+    // Workaround of https://github.com/llvm/llvm-project/issues/40056
     cSettings.append(.unsafeFlags(["-Xclang", "-fno-split-cold-code"]))
     cSettings.append(.unsafeFlags(["-Wdeprecated-declarations"]))
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -74,5 +74,5 @@ let package = Package(
             linkerSettings: linkerSettings
         )
     ],
-    cxxLanguageStandard: .cxx14
+    cxxLanguageStandard: .cxx17
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ var resources: [Resource] = []
 var linkerSettings: [LinkerSetting] = []
 var cSettings: [CSetting] =  [
     // .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
-    // .unsafeFlags(["-fno-objc-arc"]),
+    // Workaround of https://github.com/llvm/llvm-project/issues/40056
     // NOTE: NEW_LAPACK will required iOS version 16.4+
     // We should consider add this in the future when we drop support for iOS 14
     // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
@@ -39,6 +39,11 @@ cSettings.append(
 
 #if os(Linux)
     cSettings.append(.define("_GNU_SOURCE"))
+#endif
+
+#if os(Windows)
+    cSettings.append(.unsafeFlags(["-Xclang", "-fno-split-cold-code"]))
+    cSettings.append(.unsafeFlags(["-Wdeprecated-declarations"]))
 #endif
 
 let package = Package(
@@ -74,5 +79,5 @@ let package = Package(
             linkerSettings: linkerSettings
         )
     ],
-    cxxLanguageStandard: .cxx17
+    cxxLanguageStandard: .cxx14
 )

--- a/Package.swift
+++ b/Package.swift
@@ -74,5 +74,5 @@ let package = Package(
             linkerSettings: linkerSettings
         )
     ],
-    cxxLanguageStandard: .cxx11
+    cxxLanguageStandard: .cxx14
 )


### PR DESCRIPTION
- C++のバージョンを14に上げる
- llvmのエラーを回避するためのワークアラウンド（`-fno-split-cold-code`）を追加

C++のバージョンアップに関してはLinux,macOSともに影響あるかもしれないのでテストしてもらってからPR通してもらえると助かります